### PR TITLE
Update `createClient` parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 The easiest way to install this client is to simply include the built distribution from the [jsDelivr](https://www.jsdelivr.com/) CDN.
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/swiftype-app-search-javascript@1.0.3"></script>
+<script src="https://cdn.jsdelivr.net/npm/swiftype-app-search-javascript@1.2.0"></script>
 ```
 
 This will make the client available globally at:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swiftype-app-search-javascript",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Javascript client for the Swiftype App Search Api",
   "main": "public/bundle.js",
   "module": "dist/swiftype_app_search.js",

--- a/src/client.js
+++ b/src/client.js
@@ -4,10 +4,10 @@ import _omit from 'lodash/omit'
 import ResultList from './result_list'
 
 export default class Client {
-  constructor(accountHostKey, apiKey, engineName) {
+  constructor(hostIdentifier, apiKey, engineName) {
     this.apiKey = apiKey
     this.engineName = engineName
-    this.apiEndpoint = `https://${accountHostKey}.api.swiftype.com/api/as/v1/`
+    this.apiEndpoint = `https://${hostIdentifier}.api.swiftype.com/api/as/v1/`
     this.searchPath = `engines/${this.engineName}/search`
     this.clickPath = `engines/${this.engineName}/click`
   }

--- a/src/swiftype_app_search.js
+++ b/src/swiftype_app_search.js
@@ -2,6 +2,7 @@
 
 import Client from './client'
 
-export function createClient({accountHostKey, apiKey, engineName}) {
-  return new Client(accountHostKey, apiKey, engineName)
+export function createClient({hostIdentifier, accountHostKey, apiKey, engineName}) {
+  hostIdentifier = hostIdentifier || accountHostKey; // accountHostKey is deprecated
+  return new Client(hostIdentifier, apiKey, engineName)
 }

--- a/tests/swiftype_app_search.spec.js
+++ b/tests/swiftype_app_search.spec.js
@@ -1,0 +1,28 @@
+import {createClient} from "../src/swiftype_app_search";
+import Client from "../src/client";
+
+const hostIdentifier = "host-2376rb";
+const searchKey = "api-hean6g8dmxnm2shqqiag757a";
+const engineName = "node-modules";
+
+describe("SwiftypeAppSearch#createClient", () => {
+  test("instantiates a new client", () => {
+    var client = createClient({
+      hostIdentifier,
+      searchKey,
+      engineName
+    })
+
+    expect(client).toBeInstanceOf(Client);
+  });
+
+  test("instantiates a new client with deprecates accountHostKey parameter", () => {
+    var client = createClient({
+      accountHostKey: hostIdentifier,
+      searchKey,
+      engineName
+    })
+
+    expect(client).toBeInstanceOf(Client);
+  });
+});


### PR DESCRIPTION
- Expects key "hostIdentifier" instead of "accountHostKey", but
  includes backwards support for compatability.