### PR TITLE
Fixes #11: Invalid click param

### DIFF
--- a/fixtures/host-2376rb.api.swiftype.com-443/153080082771239790
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153080082771239790
@@ -3,10 +3,10 @@ authorization: Bearer api-hean6g8dmxnm2shqqiag757a
 content-type: application/json
 accept: */*
 accept-encoding: gzip,deflate
-body: {\"query\":\"Cat\",\"document_id\":\"rex-cli\",\"search_request_id\":\"8b55561954484f13d872728f849ffd22\",\"tags\":[]}
+body: {\"query\":\"Cat\",\"document_id\":\"rex-cli\",\"request_id\":\"8b55561954484f13d872728f849ffd22\",\"tags\":[\"Cat\"]}
 
 HTTP/1.1 200 OK
-date: Tue, 15 May 2018 17:14:53 GMT
+date: Thu, 05 Jul 2018 14:27:07 GMT
 content-type: application/json
 transfer-encoding: chunked
 connection: close
@@ -16,8 +16,8 @@ x-frame-options: SAMEORIGIN
 x-xss-protection: 1; mode=block
 x-content-type-options: nosniff
 cache-control: no-cache
-x-request-id: 6b49845a2d29f933d1205a650d3b0d00
-x-runtime: 0.087313
+x-request-id: 8f27fd02a0118ecae9d64a69a76837d3
+x-runtime: 0.234436
 x-swiftype-datacenter: dal05
 x-swiftype-frontend-node: web02.dal05
 x-swiftype-edge-node: web02.dal05

--- a/fixtures/host-2376rb.api.swiftype.com-443/153080082815954832
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153080082815954832
@@ -3,10 +3,10 @@ authorization: Bearer api-hean6g8dmxnm2shqqiag757a
 content-type: application/json
 accept: */*
 accept-encoding: gzip,deflate
-body: {\"query\":\"Cat\",\"document_id\":\"rex-cli\",\"search_request_id\":\"8b55561954484f13d872728f849ffd22\",\"tags\":[\"Cat\"]}
+body: {\"query\":\"Cat\",\"document_id\":\"rex-cli\",\"request_id\":\"8b55561954484f13d872728f849ffd22\",\"tags\":[]}
 
 HTTP/1.1 200 OK
-date: Tue, 15 May 2018 17:14:53 GMT
+date: Thu, 05 Jul 2018 14:27:08 GMT
 content-type: application/json
 transfer-encoding: chunked
 connection: close
@@ -16,8 +16,8 @@ x-frame-options: SAMEORIGIN
 x-xss-protection: 1; mode=block
 x-content-type-options: nosniff
 cache-control: no-cache
-x-request-id: 8666eb8bce32d8f1a94728b54796913d
-x-runtime: 0.061761
+x-request-id: 8fa7eeb2f54573fd9e856c1ce3d8e8a5
+x-runtime: 0.224629
 x-swiftype-datacenter: dal05
 x-swiftype-frontend-node: web02.dal05
 x-swiftype-edge-node: web02.dal05

--- a/src/client.js
+++ b/src/client.js
@@ -42,7 +42,7 @@ export default class Client {
     const params = {
       query,
       document_id: documentId,
-      search_request_id: requestId,
+      request_id: requestId,
       tags
     }
 


### PR DESCRIPTION
The "click" method was sending a parameter called "search_request_id",
which is not what the API expects. The API expects "request_id".