### PR TITLE
Added Disjunctive Facets and Response Caching

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,9 +2,12 @@
   "env": {
     "dev": {
       "presets": [
-        ["env", {
-          "modules": false
-        }]
+        [
+          "env",
+          {
+            "modules": false
+          }
+        ]
       ],
       "plugins": ["external-helpers"]
     },

--- a/.babelrc
+++ b/.babelrc
@@ -9,7 +9,7 @@
           }
         ]
       ],
-      "plugins": ["external-helpers"]
+      "plugins": ["external-helpers", "transform-object-rest-spread"]
     },
     "test": {
       "presets": ["env"]

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,8 @@
     "es6": true
   },
   "parserOptions": {
-    "sourceType": "module"
+    "sourceType": "module",
+    "ecmaVersion": "2018"
   },
   "rules": {
     "no-debugger": 2

--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ client
 
 Note that `options` supports all options listed here: https://swiftype.com/documentation/app-search/guides/search.
 
+In addition to the support option above, we also support the following
+additional fields:
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| disjunctiveFacets | Array[String] | An array of field names. Every field listed here must also be provided as a facet in the `facet` field. It denotes that a facet should be considered disjunctive. When returning counts for disjunctive facets, the counts will be returned as if no filter is applied on this field, even if one is applied.
+
 #### Clickthrough Tracking
 
 ```javascript
@@ -177,7 +183,7 @@ yarn publish
 
 The specs in this project use [node-replay](https://github.com/assaf/node-replay) to capture responses.
 
-The responses are then check against Jest snapshots.
+The responses are then checked against Jest snapshots.
 
 To capture new responses and update snapshots, run tests with the following commands:
 

--- a/README.md
+++ b/README.md
@@ -90,8 +90,7 @@ client
 
 Note that `options` supports all options listed here: https://swiftype.com/documentation/app-search/guides/search.
 
-In addition to the support option above, we also support the following
-additional fields:
+In addition to the supported options above, we also support the following fields:
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | disjunctiveFacets | Array[String] | An array of field names. Every field listed here must also be provided as a facet in the `facet` field. It denotes that a facet should be considered disjunctive. When returning counts for disjunctive facets, the counts will be returned as if no filter is applied on this field, even if one is applied.

--- a/fixtures/host-2376rb.api.swiftype.com-443/153807992403948584
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153807992403948584
@@ -1,0 +1,29 @@
+POST /api/as/v1/engines/node-modules/search.json
+authorization: Bearer api-hean6g8dmxnm2shqqiag757a
+content-type: application/json
+x-swiftype-client: swiftype-app-search-javascript
+x-swiftype-client-version: 1.4.0
+accept: */*
+accept-encoding: gzip,deflate
+body: {\"query\":\"cat\",\"page\":{\"size\":1},\"filters\":{\"license\":[\"BSD\"]},\"facets\":{\"license\":[{\"type\":\"value\",\"size\":3}]}}
+
+HTTP/1.1 200 OK
+date: Thu, 27 Sep 2018 20:25:24 GMT
+content-type: application/json; charset=utf-8
+transfer-encoding: chunked
+connection: close
+vary: Accept-Encoding, Origin
+status: 200 OK
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+x-content-type-options: nosniff
+etag: W/"bc55d148b47669f6cf4081f8c4893888"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: de13ba490e5bbc0be2a64f21d39d22c2
+x-runtime: 0.304407
+x-swiftype-frontend-datacenter: dal05
+x-swiftype-frontend-node: web02.dal05
+x-swiftype-edge-datacenter: dal05
+x-swiftype-edge-node: web02.dal05
+
+{"meta":{"warnings":[],"page":{"current":1,"total_pages":33,"total_results":33,"size":1},"request_id":"de13ba490e5bbc0be2a64f21d39d22c2"},"results":[{"license":{"raw":["BSD"]},"name":{"raw":"source-map-cat"},"repository":{"raw":null},"created":{"raw":"2013-01-23T04:51:39.995Z"},"dependencies":{"raw":["coffee-script","argparse","source-map"]},"keywords":{"raw":null},"description":{"raw":"WIP cat for JS source maps."},"modified":{"raw":"2013-01-23T04:51:42.782Z"},"id":{"raw":"source-map-cat"},"version":{"raw":"0.0.0"},"owners":{"raw":["gregg@aweber.com"]},"_meta":{"score":18.773478}}],"facets":{"license":[{"type":"value","data":[{"value":"BSD","count":33}]}]}}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153808056889343122
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153808056889343122
@@ -1,0 +1,29 @@
+POST /api/as/v1/engines/node-modules/search.json
+authorization: Bearer api-hean6g8dmxnm2shqqiag757a
+content-type: application/json
+x-swiftype-client: swiftype-app-search-javascript
+x-swiftype-client-version: 1.4.0
+accept: */*
+accept-encoding: gzip,deflate
+body: {\"query\":\"cat\",\"page\":{\"size\":1},\"filters\":{},\"facets\":{\"license\":[{\"type\":\"value\",\"size\":3}]}}
+
+HTTP/1.1 200 OK
+date: Thu, 27 Sep 2018 20:36:08 GMT
+content-type: application/json; charset=utf-8
+transfer-encoding: chunked
+connection: close
+vary: Accept-Encoding, Origin
+status: 200 OK
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+x-content-type-options: nosniff
+etag: W/"d31aa222a68122cb8392577cf4a1a7f1"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: 91197d45d104a3e2281a60eecec630ff
+x-runtime: 0.270027
+x-swiftype-frontend-datacenter: dal05
+x-swiftype-frontend-node: web01.dal05
+x-swiftype-edge-datacenter: dal05
+x-swiftype-edge-node: web01.dal05
+
+{"meta":{"warnings":[],"page":{"current":1,"total_pages":642,"total_results":642,"size":1},"request_id":"91197d45d104a3e2281a60eecec630ff"},"results":[{"license":{"raw":["BSD"]},"name":{"raw":"source-map-cat"},"repository":{"raw":null},"created":{"raw":"2013-01-23T04:51:39.995Z"},"dependencies":{"raw":["coffee-script","argparse","source-map"]},"keywords":{"raw":null},"description":{"raw":"WIP cat for JS source maps."},"modified":{"raw":"2013-01-23T04:51:42.782Z"},"id":{"raw":"source-map-cat"},"version":{"raw":"0.0.0"},"owners":{"raw":["gregg@aweber.com"]},"_meta":{"score":19.12111}}],"facets":{"license":[{"type":"value","data":[{"value":"MIT","count":101},{"value":"BSD","count":33},{"value":"MIT/X11","count":3}]}]}}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153808069048457806
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153808069048457806
@@ -1,0 +1,29 @@
+POST /api/as/v1/engines/node-modules/search.json
+authorization: Bearer api-hean6g8dmxnm2shqqiag757a
+content-type: application/json
+x-swiftype-client: swiftype-app-search-javascript
+x-swiftype-client-version: 1.4.0
+accept: */*
+accept-encoding: gzip,deflate
+body: {\"query\":\"cat\",\"page\":{\"size\":1},\"facets\":{\"license\":[{\"type\":\"value\",\"size\":3}]}}
+
+HTTP/1.1 200 OK
+date: Thu, 27 Sep 2018 20:38:10 GMT
+content-type: application/json; charset=utf-8
+transfer-encoding: chunked
+connection: close
+vary: Accept-Encoding, Origin
+status: 200 OK
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+x-content-type-options: nosniff
+etag: W/"51fb04efdd9d084b72a29ace4b4f7a9a"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: 5c606cea837bdcfee3fc343876beda7b
+x-runtime: 0.231739
+x-swiftype-frontend-datacenter: dal05
+x-swiftype-frontend-node: web02.dal05
+x-swiftype-edge-datacenter: dal05
+x-swiftype-edge-node: web02.dal05
+
+{"meta":{"warnings":[],"page":{"current":1,"total_pages":642,"total_results":642,"size":1},"request_id":"5c606cea837bdcfee3fc343876beda7b"},"results":[{"license":{"raw":["BSD"]},"name":{"raw":"source-map-cat"},"repository":{"raw":null},"created":{"raw":"2013-01-23T04:51:39.995Z"},"dependencies":{"raw":["coffee-script","argparse","source-map"]},"keywords":{"raw":null},"description":{"raw":"WIP cat for JS source maps."},"modified":{"raw":"2013-01-23T04:51:42.782Z"},"id":{"raw":"source-map-cat"},"version":{"raw":"0.0.0"},"owners":{"raw":["gregg@aweber.com"]},"_meta":{"score":18.773478}}],"facets":{"license":[{"type":"value","data":[{"value":"MIT","count":101},{"value":"BSD","count":33},{"value":"MIT/X11","count":3}]}]}}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153808095050430394
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153808095050430394
@@ -1,0 +1,29 @@
+POST /api/as/v1/engines/node-modules/search.json
+authorization: Bearer api-hean6g8dmxnm2shqqiag757a
+content-type: application/json
+x-swiftype-client: swiftype-app-search-javascript
+x-swiftype-client-version: 1.4.0
+accept: */*
+accept-encoding: gzip,deflate
+body: {\"query\":\"cat\",\"page\":{\"size\":1},\"filters\":{\"license\":[\"BSD\"]},\"facets\":{\"license\":[{\"type\":\"value\",\"size\":3}],\"dependencies\":[{\"type\":\"value\",\"size\":3}]}}
+
+HTTP/1.1 200 OK
+date: Thu, 27 Sep 2018 20:42:30 GMT
+content-type: application/json; charset=utf-8
+transfer-encoding: chunked
+connection: close
+vary: Accept-Encoding, Origin
+status: 200 OK
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+x-content-type-options: nosniff
+etag: W/"871b8465ba5d18f716d57411af4cd26c"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: 5feca3fb61a3b4db5796112e4748ac57
+x-runtime: 0.149278
+x-swiftype-frontend-datacenter: dal05
+x-swiftype-frontend-node: web02.dal05
+x-swiftype-edge-datacenter: dal05
+x-swiftype-edge-node: web02.dal05
+
+{"meta":{"warnings":[],"page":{"current":1,"total_pages":33,"total_results":33,"size":1},"request_id":"5feca3fb61a3b4db5796112e4748ac57"},"results":[{"license":{"raw":["BSD"]},"name":{"raw":"source-map-cat"},"repository":{"raw":null},"created":{"raw":"2013-01-23T04:51:39.995Z"},"dependencies":{"raw":["coffee-script","argparse","source-map"]},"keywords":{"raw":null},"description":{"raw":"WIP cat for JS source maps."},"modified":{"raw":"2013-01-23T04:51:42.782Z"},"id":{"raw":"source-map-cat"},"version":{"raw":"0.0.0"},"owners":{"raw":["gregg@aweber.com"]},"_meta":{"score":19.12111}}],"facets":{"dependencies":[{"type":"value","data":[{"value":"request","count":5},{"value":"socket.io","count":5},{"value":"express","count":4}]}],"license":[{"type":"value","data":[{"value":"BSD","count":33}]}]}}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153808113971638943
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153808113971638943
@@ -1,0 +1,29 @@
+POST /api/as/v1/engines/node-modules/search.json
+authorization: Bearer api-hean6g8dmxnm2shqqiag757a
+content-type: application/json
+x-swiftype-client: swiftype-app-search-javascript
+x-swiftype-client-version: 1.4.0
+accept: */*
+accept-encoding: gzip,deflate
+body: {\"query\":\"cat\",\"page\":{\"size\":1},\"facets\":{\"license\":[{\"type\":\"value\",\"size\":3}],\"dependencies\":[{\"type\":\"value\",\"size\":3}]}}
+
+HTTP/1.1 200 OK
+date: Thu, 27 Sep 2018 20:45:39 GMT
+content-type: application/json; charset=utf-8
+transfer-encoding: chunked
+connection: close
+vary: Accept-Encoding, Origin
+status: 200 OK
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+x-content-type-options: nosniff
+etag: W/"f001ab18053ede3b2cfb60267569ed87"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: 45219b36fbd0c360acf96bd1d0c46c50
+x-runtime: 0.157922
+x-swiftype-frontend-datacenter: dal05
+x-swiftype-frontend-node: web02.dal05
+x-swiftype-edge-datacenter: dal05
+x-swiftype-edge-node: web02.dal05
+
+{"meta":{"warnings":[],"page":{"current":1,"total_pages":642,"total_results":642,"size":1},"request_id":"45219b36fbd0c360acf96bd1d0c46c50"},"results":[{"license":{"raw":["BSD"]},"name":{"raw":"source-map-cat"},"repository":{"raw":null},"created":{"raw":"2013-01-23T04:51:39.995Z"},"dependencies":{"raw":["coffee-script","argparse","source-map"]},"keywords":{"raw":null},"description":{"raw":"WIP cat for JS source maps."},"modified":{"raw":"2013-01-23T04:51:42.782Z"},"id":{"raw":"source-map-cat"},"version":{"raw":"0.0.0"},"owners":{"raw":["gregg@aweber.com"]},"_meta":{"score":19.12111}}],"facets":{"dependencies":[{"type":"value","data":[{"value":"underscore","count":67},{"value":"pkginfo","count":49},{"value":"express","count":48}]}],"license":[{"type":"value","data":[{"value":"MIT","count":101},{"value":"BSD","count":33},{"value":"MIT/X11","count":3}]}]}}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153808163615616239
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153808163615616239
@@ -1,0 +1,29 @@
+POST /api/as/v1/engines/node-modules/search.json
+authorization: Bearer api-hean6g8dmxnm2shqqiag757a
+content-type: application/json
+x-swiftype-client: swiftype-app-search-javascript
+x-swiftype-client-version: 1.4.0
+accept: */*
+accept-encoding: gzip,deflate
+body: {\"query\":\"cat\",\"page\":{\"size\":1},\"filters\":{\"license\":\"BSD\"},\"facets\":{\"license\":[{\"type\":\"value\",\"size\":3}],\"dependencies\":[{\"type\":\"value\",\"size\":3}]}}
+
+HTTP/1.1 200 OK
+date: Thu, 27 Sep 2018 20:53:56 GMT
+content-type: application/json; charset=utf-8
+transfer-encoding: chunked
+connection: close
+vary: Accept-Encoding, Origin
+status: 200 OK
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+x-content-type-options: nosniff
+etag: W/"5010d52221547ddec5baceeb9f8a4931"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: 8369bdda4d5c018ddbd85fc2859fbadb
+x-runtime: 0.212519
+x-swiftype-frontend-datacenter: dal05
+x-swiftype-frontend-node: web01.dal05
+x-swiftype-edge-datacenter: dal05
+x-swiftype-edge-node: web01.dal05
+
+{"meta":{"warnings":[],"page":{"current":1,"total_pages":33,"total_results":33,"size":1},"request_id":"8369bdda4d5c018ddbd85fc2859fbadb"},"results":[{"license":{"raw":["BSD"]},"name":{"raw":"source-map-cat"},"repository":{"raw":null},"created":{"raw":"2013-01-23T04:51:39.995Z"},"dependencies":{"raw":["coffee-script","argparse","source-map"]},"keywords":{"raw":null},"description":{"raw":"WIP cat for JS source maps."},"modified":{"raw":"2013-01-23T04:51:42.782Z"},"id":{"raw":"source-map-cat"},"version":{"raw":"0.0.0"},"owners":{"raw":["gregg@aweber.com"]},"_meta":{"score":18.773478}}],"facets":{"dependencies":[{"type":"value","data":[{"value":"request","count":5},{"value":"socket.io","count":5},{"value":"express","count":4}]}],"license":[{"type":"value","data":[{"value":"BSD","count":33}]}]}}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153808178540179732
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153808178540179732
@@ -1,0 +1,29 @@
+POST /api/as/v1/engines/node-modules/search.json
+authorization: Bearer api-hean6g8dmxnm2shqqiag757a
+content-type: application/json
+x-swiftype-client: swiftype-app-search-javascript
+x-swiftype-client-version: 1.4.0
+accept: */*
+accept-encoding: gzip,deflate
+body: {\"query\":\"cat\",\"page\":{\"size\":1},\"filters\":{},\"facets\":{\"dependencies\":[{\"type\":\"value\",\"size\":3}]}}
+
+HTTP/1.1 200 OK
+date: Thu, 27 Sep 2018 20:56:25 GMT
+content-type: application/json; charset=utf-8
+transfer-encoding: chunked
+connection: close
+vary: Accept-Encoding, Origin
+status: 200 OK
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+x-content-type-options: nosniff
+etag: W/"8a7c744a234b2279794291c904ec9d6a"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: 4fa98a641e003abaaa10a02aa7f13a95
+x-runtime: 0.181080
+x-swiftype-frontend-datacenter: dal05
+x-swiftype-frontend-node: web02.dal05
+x-swiftype-edge-datacenter: dal05
+x-swiftype-edge-node: web02.dal05
+
+{"meta":{"warnings":[],"page":{"current":1,"total_pages":642,"total_results":642,"size":1},"request_id":"4fa98a641e003abaaa10a02aa7f13a95"},"results":[{"license":{"raw":["BSD"]},"name":{"raw":"source-map-cat"},"repository":{"raw":null},"created":{"raw":"2013-01-23T04:51:39.995Z"},"dependencies":{"raw":["coffee-script","argparse","source-map"]},"keywords":{"raw":null},"description":{"raw":"WIP cat for JS source maps."},"modified":{"raw":"2013-01-23T04:51:42.782Z"},"id":{"raw":"source-map-cat"},"version":{"raw":"0.0.0"},"owners":{"raw":["gregg@aweber.com"]},"_meta":{"score":19.12111}}],"facets":{"dependencies":[{"type":"value","data":[{"value":"underscore","count":67},{"value":"pkginfo","count":49},{"value":"express","count":48}]}]}}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153808178542296611
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153808178542296611
@@ -1,0 +1,29 @@
+POST /api/as/v1/engines/node-modules/search.json
+authorization: Bearer api-hean6g8dmxnm2shqqiag757a
+content-type: application/json
+x-swiftype-client: swiftype-app-search-javascript
+x-swiftype-client-version: 1.4.0
+accept: */*
+accept-encoding: gzip,deflate
+body: {\"query\":\"cat\",\"page\":{\"size\":1},\"filters\":{\"dependencies\":\"socket.io\"},\"facets\":{\"license\":[{\"type\":\"value\",\"size\":3}]}}
+
+HTTP/1.1 200 OK
+date: Thu, 27 Sep 2018 20:56:25 GMT
+content-type: application/json; charset=utf-8
+transfer-encoding: chunked
+connection: close
+vary: Accept-Encoding, Origin
+status: 200 OK
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+x-content-type-options: nosniff
+etag: W/"c7e8ffcfadb52d4aff9f38657ecda64c"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: 6fc3009b10e7a86755f812b6722dfe86
+x-runtime: 0.213533
+x-swiftype-frontend-datacenter: dal05
+x-swiftype-frontend-node: web02.dal05
+x-swiftype-edge-datacenter: dal05
+x-swiftype-edge-node: web02.dal05
+
+{"meta":{"warnings":[],"page":{"current":1,"total_pages":28,"total_results":28,"size":1},"request_id":"6fc3009b10e7a86755f812b6722dfe86"},"results":[{"license":{"raw":null},"name":{"raw":"brainy-server"},"repository":{"raw":["https://github.com/brainyio/brainy-server"]},"created":{"raw":"2013-02-18T07:37:10.852Z"},"dependencies":{"raw":["backbone","brainy-sync-api","brainy-sync","express","file","nconf","requirejs","socket.io","underscore"]},"keywords":{"raw":["brainy","backbone","client","framework"]},"description":{"raw":"a server side and client side framework for Backbone"},"modified":{"raw":"2013-03-02T20:46:27.738Z"},"id":{"raw":"brainy-server"},"version":{"raw":"0.0.5"},"owners":{"raw":["caden@catshirt.net"]},"_meta":{"score":0.45596027}}],"facets":{"license":[{"type":"value","data":[{"value":"BSD","count":5},{"value":"MIT","count":3},{"value":"GPL","count":1}]}]}}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153808227733258899
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153808227733258899
@@ -1,0 +1,29 @@
+POST /api/as/v1/engines/node-modules/search.json
+authorization: Bearer api-hean6g8dmxnm2shqqiag757a
+content-type: application/json
+x-swiftype-client: swiftype-app-search-javascript
+x-swiftype-client-version: 1.4.0
+accept: */*
+accept-encoding: gzip,deflate
+body: {\"query\":\"cat\",\"page\":{\"size\":1},\"filters\":{\"all\":[]},\"facets\":{\"dependencies\":[{\"type\":\"value\",\"size\":3}]}}
+
+HTTP/1.1 200 OK
+date: Thu, 27 Sep 2018 21:04:37 GMT
+content-type: application/json; charset=utf-8
+transfer-encoding: chunked
+connection: close
+vary: Accept-Encoding, Origin
+status: 200 OK
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+x-content-type-options: nosniff
+etag: W/"e7bc3a4924a3cc2920f2e74abcee7c3b"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: 96d5a9bbcae70b0bb7a5e11b34b61891
+x-runtime: 0.123469
+x-swiftype-frontend-datacenter: dal05
+x-swiftype-frontend-node: web02.dal05
+x-swiftype-edge-datacenter: dal05
+x-swiftype-edge-node: web02.dal05
+
+{"meta":{"warnings":[],"page":{"current":1,"total_pages":642,"total_results":642,"size":1},"request_id":"96d5a9bbcae70b0bb7a5e11b34b61891"},"results":[{"license":{"raw":["BSD"]},"name":{"raw":"source-map-cat"},"repository":{"raw":null},"created":{"raw":"2013-01-23T04:51:39.995Z"},"dependencies":{"raw":["coffee-script","argparse","source-map"]},"keywords":{"raw":null},"description":{"raw":"WIP cat for JS source maps."},"modified":{"raw":"2013-01-23T04:51:42.782Z"},"id":{"raw":"source-map-cat"},"version":{"raw":"0.0.0"},"owners":{"raw":["gregg@aweber.com"]},"_meta":{"score":18.773478}}],"facets":{"dependencies":[{"type":"value","data":[{"value":"underscore","count":67},{"value":"pkginfo","count":49},{"value":"express","count":48}]}]}}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153808227737563491
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153808227737563491
@@ -1,0 +1,29 @@
+POST /api/as/v1/engines/node-modules/search.json
+authorization: Bearer api-hean6g8dmxnm2shqqiag757a
+content-type: application/json
+x-swiftype-client: swiftype-app-search-javascript
+x-swiftype-client-version: 1.4.0
+accept: */*
+accept-encoding: gzip,deflate
+body: {\"query\":\"cat\",\"page\":{\"size\":1},\"filters\":{\"all\":[{\"dependencies\":\"socket.io\"}]},\"facets\":{\"license\":[{\"type\":\"value\",\"size\":3}]}}
+
+HTTP/1.1 200 OK
+date: Thu, 27 Sep 2018 21:04:37 GMT
+content-type: application/json; charset=utf-8
+transfer-encoding: chunked
+connection: close
+vary: Accept-Encoding, Origin
+status: 200 OK
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+x-content-type-options: nosniff
+etag: W/"3d0a9854946dc61b9a424fa156f6c6dd"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: 97feb1c3696b7ee64633e7ce00af384f
+x-runtime: 0.173476
+x-swiftype-frontend-datacenter: dal05
+x-swiftype-frontend-node: web02.dal05
+x-swiftype-edge-datacenter: dal05
+x-swiftype-edge-node: web02.dal05
+
+{"meta":{"warnings":[],"page":{"current":1,"total_pages":28,"total_results":28,"size":1},"request_id":"97feb1c3696b7ee64633e7ce00af384f"},"results":[{"license":{"raw":null},"name":{"raw":"brainy-server"},"repository":{"raw":["https://github.com/brainyio/brainy-server"]},"created":{"raw":"2013-02-18T07:37:10.852Z"},"dependencies":{"raw":["backbone","brainy-sync-api","brainy-sync","express","file","nconf","requirejs","socket.io","underscore"]},"keywords":{"raw":["brainy","backbone","client","framework"]},"description":{"raw":"a server side and client side framework for Backbone"},"modified":{"raw":"2013-03-02T20:46:27.738Z"},"id":{"raw":"brainy-server"},"version":{"raw":"0.0.5"},"owners":{"raw":["caden@catshirt.net"]},"_meta":{"score":0.45596027}}],"facets":{"license":[{"type":"value","data":[{"value":"BSD","count":5},{"value":"MIT","count":3},{"value":"GPL","count":1}]}]}}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153808227744616148
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153808227744616148
@@ -1,0 +1,29 @@
+POST /api/as/v1/engines/node-modules/search.json
+authorization: Bearer api-hean6g8dmxnm2shqqiag757a
+content-type: application/json
+x-swiftype-client: swiftype-app-search-javascript
+x-swiftype-client-version: 1.4.0
+accept: */*
+accept-encoding: gzip,deflate
+body: {\"query\":\"cat\",\"page\":{\"size\":1},\"filters\":{\"all\":[{\"license\":\"BSD\"},{\"dependencies\":\"socket.io\"}]},\"facets\":{\"license\":[{\"type\":\"value\",\"size\":3}],\"dependencies\":[{\"type\":\"value\",\"size\":3}]}}
+
+HTTP/1.1 200 OK
+date: Thu, 27 Sep 2018 21:04:37 GMT
+content-type: application/json; charset=utf-8
+transfer-encoding: chunked
+connection: close
+vary: Accept-Encoding, Origin
+status: 200 OK
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+x-content-type-options: nosniff
+etag: W/"d685c28ab443372e8e830a960e7de602"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: c0a394d7343c0363e3a1e0b9a2a89447
+x-runtime: 0.194632
+x-swiftype-frontend-datacenter: dal05
+x-swiftype-frontend-node: web02.dal05
+x-swiftype-edge-datacenter: dal05
+x-swiftype-edge-node: web02.dal05
+
+{"meta":{"warnings":[],"page":{"current":1,"total_pages":5,"total_results":5,"size":1},"request_id":"c0a394d7343c0363e3a1e0b9a2a89447"},"results":[{"license":{"raw":["BSD"]},"name":{"raw":"battlefield-tanks"},"repository":{"raw":null},"created":{"raw":"2012-11-17T18:37:08.507Z"},"dependencies":{"raw":["express","socket.io","mongoose","caterpillar","jade","connect","underscore"]},"keywords":{"raw":["game","websocket","tank"]},"description":{"raw":"Realtime game with easeljs, node.js, mongodb and socket.io"},"modified":{"raw":"2012-11-19T17:59:43.452Z"},"id":{"raw":"battlefield-tanks"},"version":{"raw":"0.1.9"},"owners":{"raw":["tim@visualappeal.de"]},"_meta":{"score":0.17728129}}],"facets":{"dependencies":[{"type":"value","data":[{"value":"socket.io","count":5},{"value":"express","count":2},{"value":"async","count":1}]}],"license":[{"type":"value","data":[{"value":"BSD","count":5}]}]}}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153808315298088051
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153808315298088051
@@ -1,0 +1,29 @@
+POST /api/as/v1/engines/node-modules/search.json
+authorization: Bearer api-hean6g8dmxnm2shqqiag757a
+content-type: application/json
+x-swiftype-client: swiftype-app-search-javascript
+x-swiftype-client-version: 1.4.0
+accept: */*
+accept-encoding: gzip,deflate
+body: {\"query\":\"cat\",\"page\":{\"size\":1},\"filters\":{\"all\":[{\"license\":\"BSD\"}]},\"facets\":{\"dependencies\":[{\"type\":\"value\",\"size\":3}]}}
+
+HTTP/1.1 200 OK
+date: Thu, 27 Sep 2018 21:19:12 GMT
+content-type: application/json; charset=utf-8
+transfer-encoding: chunked
+connection: close
+vary: Accept-Encoding, Origin
+status: 200 OK
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+x-content-type-options: nosniff
+etag: W/"18ee65079f161780b7d9ce13afee0128"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: 0dbfcb3f3379f524c0cb5530c9e9bc16
+x-runtime: 0.130653
+x-swiftype-frontend-datacenter: dal05
+x-swiftype-frontend-node: web02.dal05
+x-swiftype-edge-datacenter: dal05
+x-swiftype-edge-node: web02.dal05
+
+{"meta":{"warnings":[],"page":{"current":1,"total_pages":33,"total_results":33,"size":1},"request_id":"0dbfcb3f3379f524c0cb5530c9e9bc16"},"results":[{"license":{"raw":["BSD"]},"name":{"raw":"source-map-cat"},"repository":{"raw":null},"created":{"raw":"2013-01-23T04:51:39.995Z"},"dependencies":{"raw":["coffee-script","argparse","source-map"]},"keywords":{"raw":null},"description":{"raw":"WIP cat for JS source maps."},"modified":{"raw":"2013-01-23T04:51:42.782Z"},"id":{"raw":"source-map-cat"},"version":{"raw":"0.0.0"},"owners":{"raw":["gregg@aweber.com"]},"_meta":{"score":18.773478}}],"facets":{"dependencies":[{"type":"value","data":[{"value":"request","count":5},{"value":"socket.io","count":5},{"value":"express","count":4}]}]}}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153816524493912475
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153816524493912475
@@ -1,0 +1,29 @@
+POST /api/as/v1/engines/node-modules/search.json
+authorization: Bearer api-hean6g8dmxnm2shqqiag757a
+content-type: application/json
+x-swiftype-client: swiftype-app-search-javascript
+x-swiftype-client-version: 1.4.0
+accept: */*
+accept-encoding: gzip,deflate
+body: {\"query\":\"cat\",\"page\":{\"size\":1},\"filters\":{\"all\":[{\"license\":\"BSD\"},{\"dependencies\":\"socket.io\"}]},\"facets\":{\"license\":{\"type\":\"value\",\"size\":3},\"dependencies\":[{\"type\":\"value\",\"size\":3}]}}
+
+HTTP/1.1 200 OK
+date: Fri, 28 Sep 2018 20:07:24 GMT
+content-type: application/json; charset=utf-8
+transfer-encoding: chunked
+connection: close
+vary: Accept-Encoding, Origin
+status: 200 OK
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+x-content-type-options: nosniff
+etag: W/"2bba9fb440214c4932629a0f695c5bec"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: 93b521c3dba5a4b9e05d77006e3b4786
+x-runtime: 0.126792
+x-swiftype-frontend-datacenter: dal05
+x-swiftype-frontend-node: web02.dal05
+x-swiftype-edge-datacenter: dal05
+x-swiftype-edge-node: web02.dal05
+
+{"meta":{"warnings":[],"page":{"current":1,"total_pages":5,"total_results":5,"size":1},"request_id":"93b521c3dba5a4b9e05d77006e3b4786"},"results":[{"license":{"raw":["BSD"]},"name":{"raw":"battlefield-tanks"},"repository":{"raw":null},"created":{"raw":"2012-11-17T18:37:08.507Z"},"dependencies":{"raw":["express","socket.io","mongoose","caterpillar","jade","connect","underscore"]},"keywords":{"raw":["game","websocket","tank"]},"description":{"raw":"Realtime game with easeljs, node.js, mongodb and socket.io"},"modified":{"raw":"2012-11-19T17:59:43.452Z"},"id":{"raw":"battlefield-tanks"},"version":{"raw":"0.1.9"},"owners":{"raw":["tim@visualappeal.de"]},"_meta":{"score":0.17728129}}],"facets":{"dependencies":[{"type":"value","data":[{"value":"socket.io","count":5},{"value":"express","count":2},{"value":"async","count":1}]}],"license":[{"type":"value","data":[{"value":"BSD","count":5}]}]}}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153816524497823898
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153816524497823898
@@ -1,0 +1,29 @@
+POST /api/as/v1/engines/node-modules/search.json
+authorization: Bearer api-hean6g8dmxnm2shqqiag757a
+content-type: application/json
+x-swiftype-client: swiftype-app-search-javascript
+x-swiftype-client-version: 1.4.0
+accept: */*
+accept-encoding: gzip,deflate
+body: {\"query\":\"cat\",\"page\":{\"size\":1},\"filters\":{\"all\":[{\"dependencies\":\"socket.io\"}]},\"facets\":{\"license\":{\"type\":\"value\",\"size\":3}}}
+
+HTTP/1.1 200 OK
+date: Fri, 28 Sep 2018 20:07:24 GMT
+content-type: application/json; charset=utf-8
+transfer-encoding: chunked
+connection: close
+vary: Accept-Encoding, Origin
+status: 200 OK
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+x-content-type-options: nosniff
+etag: W/"db276752f14b2467c16355c019ef8301"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: d5982bf521684718ed764208e3a817b6
+x-runtime: 0.187982
+x-swiftype-frontend-datacenter: dal05
+x-swiftype-frontend-node: web02.dal05
+x-swiftype-edge-datacenter: dal05
+x-swiftype-edge-node: web02.dal05
+
+{"meta":{"warnings":[],"page":{"current":1,"total_pages":28,"total_results":28,"size":1},"request_id":"d5982bf521684718ed764208e3a817b6"},"results":[{"license":{"raw":null},"name":{"raw":"brainy-server"},"repository":{"raw":["https://github.com/brainyio/brainy-server"]},"created":{"raw":"2013-02-18T07:37:10.852Z"},"dependencies":{"raw":["backbone","brainy-sync-api","brainy-sync","express","file","nconf","requirejs","socket.io","underscore"]},"keywords":{"raw":["brainy","backbone","client","framework"]},"description":{"raw":"a server side and client side framework for Backbone"},"modified":{"raw":"2013-03-02T20:46:27.738Z"},"id":{"raw":"brainy-server"},"version":{"raw":"0.0.5"},"owners":{"raw":["caden@catshirt.net"]},"_meta":{"score":0.45596027}}],"facets":{"license":[{"type":"value","data":[{"value":"BSD","count":5},{"value":"MIT","count":3},{"value":"GPL","count":1}]}]}}

--- a/package.json
+++ b/package.json
@@ -32,12 +32,15 @@
     "url": "https://github.com/swiftype/swiftype-app-search-javascript/issues"
   },
   "homepage": "https://github.com/swiftype/swiftype-app-search-javascript",
-  "dependencies": {},
+  "dependencies": {
+    "object-hash": "^1.3.0"
+  },
   "devDependencies": {
     "babel-cli": "^6.24.1",
     "babel-core": "^6.26.3",
     "babel-jest": "^22.4.3",
     "babel-plugin-external-helpers": "^6.22.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "babel-runtime": "^6.9.2",
     "eslint": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "babel-jest": "^22.4.3",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-preset-env": "^1.6.1",
-    "babel-preset-es2015": "^6.9.0",
     "babel-runtime": "^6.9.2",
     "eslint": "^5.1.0",
     "eslint-config-prettier": "^2.9.0",

--- a/src/client.js
+++ b/src/client.js
@@ -30,8 +30,14 @@ function formatResultsJSON(json) {
 }
 
 export default class Client {
-  constructor(hostIdentifier, apiKey, engineName, { endpointBase = "" } = {}) {
+  constructor(
+    hostIdentifier,
+    apiKey,
+    engineName,
+    { endpointBase = "", cacheResponses = false } = {}
+  ) {
     this.apiKey = apiKey;
+    this.cacheResponses = cacheResponses;
     this.engineName = engineName;
     this.apiEndpoint = endpointBase
       ? `${endpointBase}/api/as/v1/`
@@ -125,7 +131,8 @@ export default class Client {
       this.apiKey,
       this.apiEndpoint,
       `${this.searchPath}.json`,
-      params
+      params,
+      this.cacheResponses
     ).then(({ response, json }) => {
       if (!response.ok) {
         throw new Error(
@@ -157,7 +164,8 @@ export default class Client {
       this.apiKey,
       this.apiEndpoint,
       `${this.clickPath}.json`,
-      params
+      params,
+      this.cacheResponses
     ).then(({ response, json }) => {
       if (!response.ok) {
         throw new Error(

--- a/src/client.js
+++ b/src/client.js
@@ -1,8 +1,8 @@
 "use strict";
 
-import { version, name } from "../package.json";
 import ResultList from "./result_list";
 import Filters from "./filters";
+import { request } from "./request.js";
 
 function omit(obj, keyToOmit) {
   if (!obj) return;
@@ -96,16 +96,19 @@ export default class Client {
   }
 
   _performSearch(params) {
-    return this._requestJSON(`${this.searchPath}.json`, params).then(
-      ({ response, json }) => {
-        if (!response.ok) {
-          throw new Error(
-            `[${response.status}]${json.errors ? " " + json.errors : ""}`
-          );
-        }
-        return json;
+    return request(
+      this.apiKey,
+      this.apiEndpoint,
+      `${this.searchPath}.json`,
+      params
+    ).then(({ response, json }) => {
+      if (!response.ok) {
+        throw new Error(
+          `[${response.status}]${json.errors ? " " + json.errors : ""}`
+        );
       }
-    );
+      return json;
+    });
   }
 
   /**
@@ -125,44 +128,18 @@ export default class Client {
       tags
     };
 
-    return this._requestJSON(`${this.clickPath}.json`, params).then(
-      ({ response, json }) => {
-        if (!response.ok) {
-          throw new Error(
-            `[${response.status}]${json.errors ? " " + json.errors : ""}`
-          );
-        }
-        return;
+    return request(
+      this.apiKey,
+      this.apiEndpoint,
+      `${this.clickPath}.json`,
+      params
+    ).then(({ response, json }) => {
+      if (!response.ok) {
+        throw new Error(
+          `[${response.status}]${json.errors ? " " + json.errors : ""}`
+        );
       }
-    );
-  }
-
-  _requestJSON(path, params) {
-    return this._request(path, params).then(response => {
-      return response
-        .json()
-        .then(json => {
-          return { response: response, json: json };
-        })
-        .catch(() => {
-          return { response: response, json: {} };
-        });
-    });
-  }
-
-  _request(path, params) {
-    const headers = new Headers({
-      Authorization: `Bearer ${this.apiKey}`,
-      "Content-Type": "application/json",
-      "X-Swiftype-Client": name,
-      "X-Swiftype-Client-Version": version
-    });
-
-    return fetch(`${this.apiEndpoint}${path}`, {
-      method: "POST",
-      headers: headers,
-      body: JSON.stringify(params),
-      credentials: "include"
+      return;
     });
   }
 }

--- a/src/filters.js
+++ b/src/filters.js
@@ -11,6 +11,10 @@ function removeObjectsFromArrayIfTheyHaveKey(array, key) {
   });
 }
 
+/**
+ * A helper for working with the JSON structure which represent
+ * filters in API requests.
+ */
 export default class Filters {
   constructor(filtersJSON = {}) {
     this.filtersJSON = filtersJSON;

--- a/src/filters.js
+++ b/src/filters.js
@@ -1,0 +1,51 @@
+function addPropertyIfKeysDoNotMatch(object, keyToAdd, valueToAdd, skipIfKey) {
+  return {
+    ...object,
+    ...(keyToAdd !== skipIfKey && { [keyToAdd]: valueToAdd })
+  };
+}
+
+function removeObjectsFromArrayIfTheyHaveKey(array, key) {
+  return array.filter(arrayValue => {
+    return !Object.entries(arrayValue).find(([valueKey]) => key === valueKey);
+  });
+}
+
+export default class Filters {
+  constructor(filtersJSON = {}) {
+    this.filtersJSON = filtersJSON;
+  }
+
+  removeFilter(filterKey) {
+    const filtersJSON = Object.entries(this.filtersJSON).reduce(
+      (acc, [key, value]) => {
+        if (!["all", "any", "none"].includes(key)) {
+          return addPropertyIfKeysDoNotMatch(acc, key, value, filterKey);
+        }
+        return {
+          ...acc,
+          [key]: removeObjectsFromArrayIfTheyHaveKey(value, filterKey)
+        };
+      },
+      {}
+    );
+    return new Filters(filtersJSON);
+  }
+
+  getListOfAppliedFilters() {
+    const set = Object.entries(this.filtersJSON).reduce((acc, [key, value]) => {
+      if (!["all", "any", "none"].includes(key)) {
+        acc.add(key);
+      } else {
+        value.forEach(nestedValue => {
+          Object.keys(nestedValue).forEach(nestedKey => {
+            acc.add(nestedKey);
+          });
+        });
+      }
+      return acc;
+    }, new Set());
+
+    return Array.from(set.values());
+  }
+}

--- a/src/query_cache.js
+++ b/src/query_cache.js
@@ -1,0 +1,19 @@
+import hash from "object-hash";
+
+export default class QueryCache {
+  constructor() {
+    this.cache = {};
+  }
+
+  getKey(method, url, params) {
+    return method + url + hash(params);
+  }
+
+  store(key, response) {
+    this.cache[key] = response;
+  }
+
+  retrieve(key) {
+    return this.cache[key];
+  }
+}

--- a/src/request.js
+++ b/src/request.js
@@ -1,0 +1,41 @@
+import { version, name } from "../package.json";
+import QueryCache from "./query_cache";
+const cache = new QueryCache();
+
+export function request(apiKey, apiEndpoint, path, params) {
+  const method = "POST";
+  const key = cache.getKey(method, apiEndpoint + path, params);
+  const cachedResult = cache.retrieve(key);
+  if (cachedResult) {
+    return Promise.resolve(cachedResult);
+  }
+
+  return _request(method, apiKey, apiEndpoint, path, params).then(response => {
+    return response
+      .json()
+      .then(json => {
+        const result = { response: response, json: json };
+        cache.store(key, result);
+        return result;
+      })
+      .catch(() => {
+        return { response: response, json: {} };
+      });
+  });
+}
+
+function _request(method, apiKey, apiEndpoint, path, params) {
+  const headers = new Headers({
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/json",
+    "X-Swiftype-Client": name,
+    "X-Swiftype-Client-Version": version
+  });
+
+  return fetch(`${apiEndpoint}${path}`, {
+    method,
+    headers,
+    body: JSON.stringify(params),
+    credentials: "include"
+  });
+}

--- a/src/request.js
+++ b/src/request.js
@@ -2,12 +2,14 @@ import { version, name } from "../package.json";
 import QueryCache from "./query_cache";
 const cache = new QueryCache();
 
-export function request(apiKey, apiEndpoint, path, params) {
+export function request(apiKey, apiEndpoint, path, params, cacheResponses) {
   const method = "POST";
   const key = cache.getKey(method, apiEndpoint + path, params);
-  const cachedResult = cache.retrieve(key);
-  if (cachedResult) {
-    return Promise.resolve(cachedResult);
+  if (cacheResponses) {
+    const cachedResult = cache.retrieve(key);
+    if (cachedResult) {
+      return Promise.resolve(cachedResult);
+    }
   }
 
   return _request(method, apiKey, apiEndpoint, path, params).then(response => {
@@ -15,7 +17,7 @@ export function request(apiKey, apiEndpoint, path, params) {
       .json()
       .then(json => {
         const result = { response: response, json: json };
-        cache.store(key, result);
+        if (cacheResponses) cache.store(key, result);
         return result;
       })
       .catch(() => {

--- a/src/swiftype_app_search.js
+++ b/src/swiftype_app_search.js
@@ -7,8 +7,12 @@ export function createClient({
   accountHostKey,
   apiKey,
   engineName,
-  endpointBase
+  endpointBase,
+  cacheResponses
 }) {
   hostIdentifier = hostIdentifier || accountHostKey; // accountHostKey is deprecated
-  return new Client(hostIdentifier, apiKey, engineName, { endpointBase });
+  return new Client(hostIdentifier, apiKey, engineName, {
+    endpointBase,
+    cacheResponses
+  });
 }

--- a/tests/__snapshots__/client.spec.js.snap
+++ b/tests/__snapshots__/client.spec.js.snap
@@ -1013,7 +1013,7 @@ ResultList {
 }
 `;
 
-exports[`Client can be instantiated with an endpointBase 1`] = `
+exports[`Client can be instantiated with options 1`] = `
 ResultList {
   "info": Object {
     "meta": Object {

--- a/tests/client.spec.js
+++ b/tests/client.spec.js
@@ -18,9 +18,10 @@ describe("Client", () => {
     expect(client).toBeInstanceOf(Client);
   });
 
-  test("can be instantiated with an endpointBase", async () => {
+  test("can be instantiated with options", async () => {
     const client = new Client(hostIdentifier, searchKey, engineName, {
-      endpointBase: "http://localhost.swiftype.com:3002"
+      endpointBase: "http://localhost.swiftype.com:3002",
+      cacheResponses: true
     });
 
     const result = await client.search("cat", {});

--- a/tests/filters.spec.js
+++ b/tests/filters.spec.js
@@ -1,0 +1,76 @@
+import Filters from "../src/filters";
+
+describe("Filters", () => {
+  test("can be instantiated", () => {
+    const filters = new Filters({});
+    expect(filters).toBeInstanceOf(Filters);
+  });
+
+  describe("#removeFilter", () => {
+    // At a top level, there can only ever be one filter applied. In other words
+    // the top level hash can have any combo of 'all', 'any', or 'none', and
+    // if they have none of those, there can be one key for one top level filter
+    test("can remove a filter at the top level", () => {
+      const filters = new Filters({
+        a: "a"
+      });
+
+      expect(filters.removeFilter("a").filtersJSON).toEqual({});
+    });
+
+    test("can be chained", () => {
+      const filters = new Filters({
+        all: [{ c: "c" }, { a: "a" }, { b: "b" }, { d: "d" }]
+      });
+
+      expect(filters.removeFilter("a").removeFilter("b").filtersJSON).toEqual({
+        all: [{ c: "c" }, { d: "d" }]
+      });
+    });
+
+    test("can remove a nested filters", () => {
+      const filters = new Filters({
+        all: [{ c: "c" }, { d: "d" }],
+        none: [{ e: "e" }, { f: "f" }],
+        any: [{ g: "g" }]
+      });
+
+      expect(
+        filters
+          .removeFilter("c")
+          .removeFilter("f")
+          .removeFilter("g").filtersJSON
+      ).toEqual({
+        all: [{ d: "d" }],
+        none: [{ e: "e" }],
+        any: []
+      });
+    });
+  });
+
+  describe("#getListOfAppliedFilters", () => {
+    test("it should return a list of top level filters", () => {
+      const filters = new Filters({
+        b: ["b", "b1"]
+      });
+
+      expect(filters.getListOfAppliedFilters()).toEqual(["b"]);
+    });
+
+    test("it include filters nested in all, any, or not", () => {
+      const filters = new Filters({
+        all: [{ c: "c" }, { d: "d" }],
+        none: [{ e: "e" }, { e: "e1" }, { f: "f" }],
+        any: [{ g: "g" }]
+      });
+
+      expect(filters.getListOfAppliedFilters()).toEqual([
+        "c",
+        "d",
+        "e",
+        "f",
+        "g"
+      ]);
+    });
+  });
+});

--- a/tests/request.spec.js
+++ b/tests/request.spec.js
@@ -17,7 +17,7 @@ describe("request", () => {
     a: "a"
   };
 
-  beforeAll(() => {
+  beforeEach(() => {
     global.Headers = Headers;
     global.fetch = jest
       .fn()
@@ -29,43 +29,61 @@ describe("request", () => {
   });
 
   it("can fetch", async () => {
-    const res = await request(apiKey, endpoint, path, params);
+    const res = await request(apiKey, endpoint, path, params, true);
     expect(res.response).toBe(response);
     expect(global.fetch.mock.calls.length).toBe(1);
   });
 
   it("will return a cached response if already called once", async () => {
-    const res = await request(apiKey, endpoint, path, params);
+    const res = await request(apiKey, endpoint, path, params, true);
     expect(res.response).toBe(response);
     expect(global.fetch.mock.calls.length).toBe(0);
   });
 
   it("will not return the cached response if endpoint changes", async () => {
-    const res = await request(apiKey, "http://www.jira.com", path, params);
+    const res = await request(
+      apiKey,
+      "http://www.jira.com",
+      path,
+      params,
+      true
+    );
     expect(res.response).toBe(response);
     expect(global.fetch.mock.calls.length).toBe(1);
   });
 
   it("will not return the cached response if path changes", async () => {
-    const res = await request(apiKey, endpoint, "/new/path", params);
+    const res = await request(apiKey, endpoint, "/new/path", params, true);
     expect(res.response).toBe(response);
     expect(global.fetch.mock.calls.length).toBe(1);
   });
 
   it("will not return the cached response if path params change", async () => {
-    const res = await request(apiKey, endpoint, path, {
-      a: "a",
-      b: "b"
-    });
+    const res = await request(
+      apiKey,
+      endpoint,
+      path,
+      {
+        a: "a",
+        b: "b"
+      },
+      true
+    );
     expect(res.response).toBe(response);
     expect(global.fetch.mock.calls.length).toBe(1);
   });
 
   it("will return another cached response", async () => {
-    const res = await request(apiKey, endpoint, path, {
-      a: "a",
-      b: "b"
-    });
+    const res = await request(
+      apiKey,
+      endpoint,
+      path,
+      {
+        a: "a",
+        b: "b"
+      },
+      true
+    );
     expect(res.response).toBe(response);
     expect(global.fetch.mock.calls.length).toBe(0);
   });
@@ -75,12 +93,18 @@ describe("request", () => {
       .fn()
       .mockImplementation(() => Promise.resolve(responseWithParsingError));
 
-    let res = await request(apiKey, "bad/endpoint", path, params);
+    let res = await request(apiKey, "bad/endpoint", path, params, true);
     expect(res.json).toEqual({});
     expect(global.fetch.mock.calls.length).toBe(1);
 
-    res = await request(apiKey, "bad/endpoint", path, params);
+    res = await request(apiKey, "bad/endpoint", path, params, true);
     expect(res.json).toEqual({});
     expect(global.fetch.mock.calls.length).toBe(2);
+  });
+
+  it("will ignore cache if cacheResponses is false", async () => {
+    const res = await request(apiKey, endpoint, path, params, false);
+    expect(res.response).toBe(response);
+    expect(global.fetch.mock.calls.length).toBe(1);
   });
 });

--- a/tests/request.spec.js
+++ b/tests/request.spec.js
@@ -1,0 +1,86 @@
+import { request } from "../src/request";
+import { Headers } from "node-fetch";
+
+describe("request", () => {
+  const responseJson = {};
+  const response = {
+    json: () => Promise.resolve(responseJson)
+  };
+  const responseWithParsingError = {
+    json: () => Promise.reject()
+  };
+
+  const apiKey = "api-12345";
+  const endpoint = "http://www.example.com";
+  const path = "/v1/search";
+  const params = {
+    a: "a"
+  };
+
+  beforeAll(() => {
+    global.Headers = Headers;
+    global.fetch = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(response));
+  });
+
+  beforeEach(() => {
+    global.fetch.mockClear();
+  });
+
+  it("can fetch", async () => {
+    const res = await request(apiKey, endpoint, path, params);
+    expect(res.response).toBe(response);
+    expect(global.fetch.mock.calls.length).toBe(1);
+  });
+
+  it("will return a cached response if already called once", async () => {
+    const res = await request(apiKey, endpoint, path, params);
+    expect(res.response).toBe(response);
+    expect(global.fetch.mock.calls.length).toBe(0);
+  });
+
+  it("will not return the cached response if endpoint changes", async () => {
+    const res = await request(apiKey, "http://www.jira.com", path, params);
+    expect(res.response).toBe(response);
+    expect(global.fetch.mock.calls.length).toBe(1);
+  });
+
+  it("will not return the cached response if path changes", async () => {
+    const res = await request(apiKey, endpoint, "/new/path", params);
+    expect(res.response).toBe(response);
+    expect(global.fetch.mock.calls.length).toBe(1);
+  });
+
+  it("will not return the cached response if path params change", async () => {
+    const res = await request(apiKey, endpoint, path, {
+      a: "a",
+      b: "b"
+    });
+    expect(res.response).toBe(response);
+    expect(global.fetch.mock.calls.length).toBe(1);
+  });
+
+  it("will return another cached response", async () => {
+    const res = await request(apiKey, endpoint, path, {
+      a: "a",
+      b: "b"
+    });
+    expect(res.response).toBe(response);
+    expect(global.fetch.mock.calls.length).toBe(0);
+  });
+
+  it("will not cache an error response", async () => {
+    global.fetch = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(responseWithParsingError));
+
+    let res = await request(apiKey, "bad/endpoint", path, params);
+    expect(res.json).toEqual({});
+    expect(global.fetch.mock.calls.length).toBe(1);
+
+    res = await request(apiKey, "bad/endpoint", path, params);
+    expect(res.json).toEqual({});
+    expect(global.fetch.mock.calls.length).toBe(2);
+  });
+});

--- a/tests/swiftype_app_search.spec.js
+++ b/tests/swiftype_app_search.spec.js
@@ -26,12 +26,13 @@ describe("SwiftypeAppSearch#createClient", () => {
     expect(client).toBeInstanceOf(Client);
   });
 
-  test("instantiates a new client with the endpointBase option", () => {
+  test("instantiates a new client with options", () => {
     var client = createClient({
       hostIdentifier,
       searchKey,
       engineName,
-      endpointBase: "http://localhost:3002"
+      endpointBase: "http://localhost:3002",
+      cacheResponses: true
     });
 
     expect(client).toBeInstanceOf(Client);

--- a/yarn.lock
+++ b/yarn.lock
@@ -544,7 +544,7 @@ babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
 
-babel-plugin-syntax-object-rest-spread@^6.13.0:
+babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
 
@@ -735,6 +735,13 @@ babel-plugin-transform-exponentiation-operator@^6.22.0:
     babel-helper-builder-binary-assignment-operator-visitor "^6.24.1"
     babel-plugin-syntax-exponentiation-operator "^6.8.0"
     babel-runtime "^6.22.0"
+
+babel-plugin-transform-object-rest-spread@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
+    babel-runtime "^6.26.0"
 
 babel-plugin-transform-regenerator@^6.22.0:
   version "6.26.0"
@@ -3446,6 +3453,10 @@ object-copy@^0.1.0:
     copy-descriptor "^0.1.0"
     define-property "^0.2.5"
     kind-of "^3.0.3"
+
+object-hash@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.0.tgz#76d9ba6ff113cf8efc0d996102851fe6723963e2"
 
 object-keys@^1.0.8:
   version "1.0.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -538,11 +538,11 @@ babel-plugin-jest-hoist@^22.4.3:
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
+  resolved "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
 
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
+  resolved "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
 
 babel-plugin-syntax-object-rest-spread@^6.13.0:
   version "6.13.0"
@@ -572,7 +572,7 @@ babel-plugin-transform-es2015-block-scoped-functions@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-block-scoping@^6.23.0, babel-plugin-transform-es2015-block-scoping@^6.24.1:
+babel-plugin-transform-es2015-block-scoping@^6.23.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz#d70f5299c1308d05c12f463813b0a09e73b1895f"
   dependencies:
@@ -582,7 +582,7 @@ babel-plugin-transform-es2015-block-scoping@^6.23.0, babel-plugin-transform-es20
     babel-types "^6.26.0"
     lodash "^4.17.4"
 
-babel-plugin-transform-es2015-classes@^6.23.0, babel-plugin-transform-es2015-classes@^6.24.1:
+babel-plugin-transform-es2015-classes@^6.23.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz#5a4c58a50c9c9461e564b4b2a3bfabc97a2584db"
   dependencies:
@@ -596,33 +596,33 @@ babel-plugin-transform-es2015-classes@^6.23.0, babel-plugin-transform-es2015-cla
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-computed-properties@^6.22.0, babel-plugin-transform-es2015-computed-properties@^6.24.1:
+babel-plugin-transform-es2015-computed-properties@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz#6fe2a8d16895d5634f4cd999b6d3480a308159b3"
   dependencies:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-es2015-destructuring@^6.22.0, babel-plugin-transform-es2015-destructuring@^6.23.0:
+babel-plugin-transform-es2015-destructuring@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz#997bb1f1ab967f682d2b0876fe358d60e765c56d"
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-duplicate-keys@^6.22.0, babel-plugin-transform-es2015-duplicate-keys@^6.24.1:
+babel-plugin-transform-es2015-duplicate-keys@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz#73eb3d310ca969e3ef9ec91c53741a6f1576423e"
   dependencies:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-for-of@^6.22.0, babel-plugin-transform-es2015-for-of@^6.23.0:
+babel-plugin-transform-es2015-for-of@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz#f47c95b2b613df1d3ecc2fdb7573623c75248691"
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-function-name@^6.22.0, babel-plugin-transform-es2015-function-name@^6.24.1:
+babel-plugin-transform-es2015-function-name@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz#834c89853bc36b1af0f3a4c5dbaa94fd8eacaa8b"
   dependencies:
@@ -644,7 +644,7 @@ babel-plugin-transform-es2015-modules-amd@^6.22.0, babel-plugin-transform-es2015
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-es2015-modules-commonjs@^6.23.0:
+babel-plugin-transform-es2015-modules-commonjs@^6.23.0, babel-plugin-transform-es2015-modules-commonjs@^6.24.1:
   version "6.26.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz#58a793863a9e7ca870bdc5a881117ffac27db6f3"
   dependencies:
@@ -653,16 +653,7 @@ babel-plugin-transform-es2015-modules-commonjs@^6.23.0:
     babel-template "^6.26.0"
     babel-types "^6.26.0"
 
-babel-plugin-transform-es2015-modules-commonjs@^6.24.1:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz#0d8394029b7dc6abe1a97ef181e00758dd2e5d8a"
-  dependencies:
-    babel-plugin-transform-strict-mode "^6.24.1"
-    babel-runtime "^6.26.0"
-    babel-template "^6.26.0"
-    babel-types "^6.26.0"
-
-babel-plugin-transform-es2015-modules-systemjs@^6.23.0, babel-plugin-transform-es2015-modules-systemjs@^6.24.1:
+babel-plugin-transform-es2015-modules-systemjs@^6.23.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz#ff89a142b9119a906195f5f106ecf305d9407d23"
   dependencies:
@@ -670,7 +661,7 @@ babel-plugin-transform-es2015-modules-systemjs@^6.23.0, babel-plugin-transform-e
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-es2015-modules-umd@^6.23.0, babel-plugin-transform-es2015-modules-umd@^6.24.1:
+babel-plugin-transform-es2015-modules-umd@^6.23.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz#ac997e6285cd18ed6176adb607d602344ad38468"
   dependencies:
@@ -678,14 +669,14 @@ babel-plugin-transform-es2015-modules-umd@^6.23.0, babel-plugin-transform-es2015
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-es2015-object-super@^6.22.0, babel-plugin-transform-es2015-object-super@^6.24.1:
+babel-plugin-transform-es2015-object-super@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz#24cef69ae21cb83a7f8603dad021f572eb278f8d"
   dependencies:
     babel-helper-replace-supers "^6.24.1"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-parameters@^6.23.0, babel-plugin-transform-es2015-parameters@^6.24.1:
+babel-plugin-transform-es2015-parameters@^6.23.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz#57ac351ab49caf14a97cd13b09f66fdf0a625f2b"
   dependencies:
@@ -696,7 +687,7 @@ babel-plugin-transform-es2015-parameters@^6.23.0, babel-plugin-transform-es2015-
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-shorthand-properties@^6.22.0, babel-plugin-transform-es2015-shorthand-properties@^6.24.1:
+babel-plugin-transform-es2015-shorthand-properties@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz#24f875d6721c87661bbd99a4622e51f14de38aa0"
   dependencies:
@@ -709,7 +700,7 @@ babel-plugin-transform-es2015-spread@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-sticky-regex@^6.22.0, babel-plugin-transform-es2015-sticky-regex@^6.24.1:
+babel-plugin-transform-es2015-sticky-regex@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz#00c1cdb1aca71112cdf0cf6126c2ed6b457ccdbc"
   dependencies:
@@ -723,13 +714,13 @@ babel-plugin-transform-es2015-template-literals@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-typeof-symbol@^6.22.0, babel-plugin-transform-es2015-typeof-symbol@^6.23.0:
+babel-plugin-transform-es2015-typeof-symbol@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz#dec09f1cddff94b52ac73d505c84df59dcceb372"
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-unicode-regex@^6.22.0, babel-plugin-transform-es2015-unicode-regex@^6.24.1:
+babel-plugin-transform-es2015-unicode-regex@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz#d38b12f42ea7323f729387f18a7c5ae1faeb35e9"
   dependencies:
@@ -745,7 +736,7 @@ babel-plugin-transform-exponentiation-operator@^6.22.0:
     babel-plugin-syntax-exponentiation-operator "^6.8.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-regenerator@^6.22.0, babel-plugin-transform-regenerator@^6.24.1:
+babel-plugin-transform-regenerator@^6.22.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz#e0703696fbde27f0a3efcacf8b4dca2f7b3a8f2f"
   dependencies:
@@ -800,35 +791,6 @@ babel-preset-env@^1.6.1:
     browserslist "^3.2.6"
     invariant "^2.2.2"
     semver "^5.3.0"
-
-babel-preset-es2015@^6.9.0:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz#d44050d6bc2c9feea702aaf38d727a0210538939"
-  dependencies:
-    babel-plugin-check-es2015-constants "^6.22.0"
-    babel-plugin-transform-es2015-arrow-functions "^6.22.0"
-    babel-plugin-transform-es2015-block-scoped-functions "^6.22.0"
-    babel-plugin-transform-es2015-block-scoping "^6.24.1"
-    babel-plugin-transform-es2015-classes "^6.24.1"
-    babel-plugin-transform-es2015-computed-properties "^6.24.1"
-    babel-plugin-transform-es2015-destructuring "^6.22.0"
-    babel-plugin-transform-es2015-duplicate-keys "^6.24.1"
-    babel-plugin-transform-es2015-for-of "^6.22.0"
-    babel-plugin-transform-es2015-function-name "^6.24.1"
-    babel-plugin-transform-es2015-literals "^6.22.0"
-    babel-plugin-transform-es2015-modules-amd "^6.24.1"
-    babel-plugin-transform-es2015-modules-commonjs "^6.24.1"
-    babel-plugin-transform-es2015-modules-systemjs "^6.24.1"
-    babel-plugin-transform-es2015-modules-umd "^6.24.1"
-    babel-plugin-transform-es2015-object-super "^6.24.1"
-    babel-plugin-transform-es2015-parameters "^6.24.1"
-    babel-plugin-transform-es2015-shorthand-properties "^6.24.1"
-    babel-plugin-transform-es2015-spread "^6.22.0"
-    babel-plugin-transform-es2015-sticky-regex "^6.24.1"
-    babel-plugin-transform-es2015-template-literals "^6.22.0"
-    babel-plugin-transform-es2015-typeof-symbol "^6.22.0"
-    babel-plugin-transform-es2015-unicode-regex "^6.24.1"
-    babel-plugin-transform-regenerator "^6.24.1"
 
 babel-preset-jest@^22.4.3:
   version "22.4.3"
@@ -984,11 +946,11 @@ browser-resolve@^1.11.2:
     resolve "1.1.7"
 
 browserslist@^3.2.6:
-  version "3.2.7"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-3.2.7.tgz#aa488634d320b55e88bab0256184dbbcca1e6de9"
+  version "3.2.8"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-3.2.8.tgz#b0005361d6471f0f5952797a76fc985f1f978fc6"
   dependencies:
-    caniuse-lite "^1.0.30000835"
-    electron-to-chromium "^1.3.45"
+    caniuse-lite "^1.0.30000844"
+    electron-to-chromium "^1.3.47"
 
 bser@^2.0.0:
   version "2.0.0"
@@ -1040,9 +1002,9 @@ camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
-caniuse-lite@^1.0.30000835:
-  version "1.0.30000840"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000840.tgz#344513f8f843536cf99694964c09811277eee395"
+caniuse-lite@^1.0.30000844:
+  version "1.0.30000887"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000887.tgz#1769458c27bbdcf61b0cb6b5072bb6cd11fd9c23"
 
 capture-exit@^1.2.0:
   version "1.2.0"
@@ -1063,7 +1025,7 @@ center-align@^0.1.1:
 
 chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
+  resolved "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
     ansi-styles "^2.2.1"
     escape-string-regexp "^1.0.2"
@@ -1231,7 +1193,11 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
-core-js@^2.4.0, core-js@^2.5.0:
+core-js@^2.4.0:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
+
+core-js@^2.5.0:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
 
@@ -1425,9 +1391,9 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
-electron-to-chromium@^1.3.45:
-  version "1.3.45"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.45.tgz#458ac1b1c5c760ce8811a16d2bfbd97ec30bafb8"
+electron-to-chromium@^1.3.47:
+  version "1.3.71"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.71.tgz#baecb282e8b27247bbfcf2f3e0254d6fe9a76789"
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -2238,8 +2204,8 @@ inquirer@^5.2.0:
     through "^2.3.6"
 
 invariant@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
     loose-envify "^1.0.0"
 
@@ -2861,6 +2827,10 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+
 js-yaml@^3.11.0, js-yaml@^3.9.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
@@ -3110,9 +3080,13 @@ lodash@^4.13.1, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
-lodash@^4.14.0, lodash@^4.17.4:
+lodash@^4.14.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+lodash@^4.17.4:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
 log-symbols@^1.0.2:
   version "1.0.2"
@@ -3138,10 +3112,10 @@ longest@^1.0.1:
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
 loose-envify@^1.0.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   dependencies:
-    js-tokens "^3.0.0"
+    js-tokens "^3.0.0 || ^4.0.0"
 
 lru-cache@^4.0.1:
   version "4.1.3"
@@ -3832,8 +3806,8 @@ realpath-native@^1.0.0:
     util.promisify "^1.0.0"
 
 regenerate@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.3.tgz#0c336d3980553d755c39b586ae3b20aa49c82b7f"
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
 
 regenerator-runtime@^0.10.5:
   version "0.10.5"
@@ -4156,9 +4130,13 @@ semver-compare@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
+semver@^5.3.0:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"


### PR DESCRIPTION
# Disjunctive Faceting

A "Disjunctive Facet" works slightly differently then a normal facet. In a "Disjunctive Facet", when selecting / filtering on a value within that facet, you do NOT want the counts to change.

A good use case for this is something like tabbed result sets:

<img width="1281" alt="screenshot 2018-10-03 13 27 05" src="https://user-images.githubusercontent.com/1427475/46427712-1a554480-c710-11e8-8a6d-fda20c6c1176.png">

In the example above, if we used regular facets for those tabs, and applied a filter every time a tab was clicked, the facet counts would change every time. For instance, if you were to click on the "Documentation" link, the facet counts would  become:

<img width="1275" alt="screenshot 2018-10-03 13 31 25" src="https://user-images.githubusercontent.com/1427475/46427949-b41cf180-c710-11e8-8f1a-b7aeaa09b089.png">

This is clearly not what we want. By denoting in a facet that we'd like it to be "Disjunctive", we are essentially saying "Always give me the counts for this facet as if a filter was not applied to this field, even if one is applied".

## Implementation of Disjunctive Facets

The `search` method on this client now supports a new option, `disjunctiveFacets`.

Ex:

```
{
  query: "test",
  facets: {
    website_area: {
      type: "value",
      size: 10
    }
  },
  disjunctiveFacets: ["website_area"]
}
```

Providing "website_area" as a `disjunctiveFacets` option works in conjunction with the facet configuration provided in the `facets` option.

What happens behind the scenes, is that there are actually typically two queries made for disjunctive facets.

That is, if a facet is defined as "disjunctive" AND there is a filter applied on that field, it will:
1) Make a search API call, as usual
2) Do one additional search API call, for each facet that meets the above criteria, but querying the results with the corresponding filter ommited
3) Merge the the results of the two responses, so that to the client consumer, this is completely transparent.

# Response Caching

Because Disjunctive Faceting can effectively double the amount of API calls, we've implemented the ability to cache API responses.

The cache is simplistic:
1) Responses are cached indefinitely
2) Cache size is infinite

This is currently "opt-in" behavior, which is only enabled by passing an additional property, `cacheResponses: true` to the `Client` constructor. The plan would be, in the next major revision, to make it opt-out behavior, so it is enabled by default.


