### PR TITLE
Release 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 The easiest way to install this client is to simply include the built distribution from the [jsDelivr](https://www.jsdelivr.com/) CDN.
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/swiftype-app-search-javascript@1.4.0/dist/swiftype_app_search.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/swiftype-app-search-javascript@2.0.0/dist/swiftype_app_search.umd.js"></script>
 ```
 
 This will make the client available globally at:

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ List of configuration options:
 | apiKey         | Yes      | Your **Public Search Key**. It should start with `search-`.                                                                                                             |
 | engineName     | Yes      |                                                                                                                                                                         |
 | endpointBase   | No       | Overrides the base of the Swiftype API endpoint completely. Useful when proxying the Swiftype API or developing against a local API server. Ex. "http://localhost:3000" |
+| cacheResponses | No       | Whether or not API responses should be cached. Default: `true`.                                                                                                         |
 
 ### API Methods
 
@@ -94,6 +95,28 @@ In addition to the supported options above, we also support the following fields
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | disjunctiveFacets | Array[String] | An array of field names. Every field listed here must also be provided as a facet in the `facet` field. It denotes that a facet should be considered disjunctive. When returning counts for disjunctive facets, the counts will be returned as if no filter is applied on this field, even if one is applied.
+
+_Response_
+
+The search method returns the response wrapped in a `ResultList` type:
+
+```javascript
+ResultList {
+  rawResults: [], // List of raw `results` from JSON response
+  rawInfo: { // Object wrapping the raw `meta` property from JSON response
+    meta: {}
+  },
+  results: [ResultItem], // List of `results` wrapped in `ResultItem` type
+  info: { // Currently the same as `rawInfo`
+    meta: {}
+  }
+}
+
+ResultItem {
+  getRaw(fieldName), // Returns the HTML-unsafe raw value for a field, if it exists
+  getSnippet(fieldName) // Returns the HTML-safe snippet value for a field, if it exists
+}
+```
 
 #### Clickthrough Tracking
 

--- a/fixtures/host-2376rb.api.swiftype.com-443/153114567899185607
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153114567899185607
@@ -2,7 +2,7 @@ POST /api/as/v1/engines/node-modules/search.json
 authorization: Bearer api-hean6g8dmxnm2shqqiag757a
 content-type: application/json
 x-swiftype-client: swiftype-app-search-javascript
-x-swiftype-client-version: 1.4.0
+x-swiftype-client-version: 2.0.0
 accept: */*
 accept-encoding: gzip,deflate
 body: {\"query\":\"cat\"}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153114567930862198
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153114567930862198
@@ -2,7 +2,7 @@ POST /api/as/v1/engines/node-modules/search.json
 authorization: Bearer api-hean6g8dmxnm2shqqiag757a
 content-type: application/json
 x-swiftype-client: swiftype-app-search-javascript
-x-swiftype-client-version: 1.4.0
+x-swiftype-client-version: 2.0.0
 accept: */*
 accept-encoding: gzip,deflate
 body: {}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153114567959665247
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153114567959665247
@@ -2,7 +2,7 @@ POST /api/as/v1/engines/node-modules/click.json
 authorization: Bearer api-hean6g8dmxnm2shqqiag757a
 content-type: application/json
 x-swiftype-client: swiftype-app-search-javascript
-x-swiftype-client-version: 1.4.0
+x-swiftype-client-version: 2.0.0
 accept: */*
 accept-encoding: gzip,deflate
 body: {\"query\":\"Cat\",\"document_id\":\"rex-cli\",\"request_id\":\"8b55561954484f13d872728f849ffd22\",\"tags\":[\"Cat\"]}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153114567986444608
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153114567986444608
@@ -2,7 +2,7 @@ POST /api/as/v1/engines/node-modules/click.json
 authorization: Bearer api-hean6g8dmxnm2shqqiag757a
 content-type: application/json
 x-swiftype-client: swiftype-app-search-javascript
-x-swiftype-client-version: 1.4.0
+x-swiftype-client-version: 2.0.0
 accept: */*
 accept-encoding: gzip,deflate
 body: {\"query\":\"Cat\",\"document_id\":\"rex-cli\",\"request_id\":\"8b55561954484f13d872728f849ffd22\",\"tags\":[]}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153114568014584568
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153114568014584568
@@ -2,7 +2,7 @@ POST /api/as/v1/engines/node-modules/click.json
 authorization: Bearer api-hean6g8dmxnm2shqqiag757a
 content-type: application/json
 x-swiftype-client: swiftype-app-search-javascript
-x-swiftype-client-version: 1.4.0
+x-swiftype-client-version: 2.0.0
 accept: */*
 accept-encoding: gzip,deflate
 body: {\"tags\":[]}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153807992403948584
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153807992403948584
@@ -2,7 +2,7 @@ POST /api/as/v1/engines/node-modules/search.json
 authorization: Bearer api-hean6g8dmxnm2shqqiag757a
 content-type: application/json
 x-swiftype-client: swiftype-app-search-javascript
-x-swiftype-client-version: 1.4.0
+x-swiftype-client-version: 2.0.0
 accept: */*
 accept-encoding: gzip,deflate
 body: {\"query\":\"cat\",\"page\":{\"size\":1},\"filters\":{\"license\":[\"BSD\"]},\"facets\":{\"license\":[{\"type\":\"value\",\"size\":3}]}}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153808056889343122
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153808056889343122
@@ -2,7 +2,7 @@ POST /api/as/v1/engines/node-modules/search.json
 authorization: Bearer api-hean6g8dmxnm2shqqiag757a
 content-type: application/json
 x-swiftype-client: swiftype-app-search-javascript
-x-swiftype-client-version: 1.4.0
+x-swiftype-client-version: 2.0.0
 accept: */*
 accept-encoding: gzip,deflate
 body: {\"query\":\"cat\",\"page\":{\"size\":1},\"filters\":{},\"facets\":{\"license\":[{\"type\":\"value\",\"size\":3}]}}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153808069048457806
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153808069048457806
@@ -2,7 +2,7 @@ POST /api/as/v1/engines/node-modules/search.json
 authorization: Bearer api-hean6g8dmxnm2shqqiag757a
 content-type: application/json
 x-swiftype-client: swiftype-app-search-javascript
-x-swiftype-client-version: 1.4.0
+x-swiftype-client-version: 2.0.0
 accept: */*
 accept-encoding: gzip,deflate
 body: {\"query\":\"cat\",\"page\":{\"size\":1},\"facets\":{\"license\":[{\"type\":\"value\",\"size\":3}]}}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153808095050430394
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153808095050430394
@@ -2,7 +2,7 @@ POST /api/as/v1/engines/node-modules/search.json
 authorization: Bearer api-hean6g8dmxnm2shqqiag757a
 content-type: application/json
 x-swiftype-client: swiftype-app-search-javascript
-x-swiftype-client-version: 1.4.0
+x-swiftype-client-version: 2.0.0
 accept: */*
 accept-encoding: gzip,deflate
 body: {\"query\":\"cat\",\"page\":{\"size\":1},\"filters\":{\"license\":[\"BSD\"]},\"facets\":{\"license\":[{\"type\":\"value\",\"size\":3}],\"dependencies\":[{\"type\":\"value\",\"size\":3}]}}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153808113971638943
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153808113971638943
@@ -2,7 +2,7 @@ POST /api/as/v1/engines/node-modules/search.json
 authorization: Bearer api-hean6g8dmxnm2shqqiag757a
 content-type: application/json
 x-swiftype-client: swiftype-app-search-javascript
-x-swiftype-client-version: 1.4.0
+x-swiftype-client-version: 2.0.0
 accept: */*
 accept-encoding: gzip,deflate
 body: {\"query\":\"cat\",\"page\":{\"size\":1},\"facets\":{\"license\":[{\"type\":\"value\",\"size\":3}],\"dependencies\":[{\"type\":\"value\",\"size\":3}]}}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153808163615616239
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153808163615616239
@@ -2,7 +2,7 @@ POST /api/as/v1/engines/node-modules/search.json
 authorization: Bearer api-hean6g8dmxnm2shqqiag757a
 content-type: application/json
 x-swiftype-client: swiftype-app-search-javascript
-x-swiftype-client-version: 1.4.0
+x-swiftype-client-version: 2.0.0
 accept: */*
 accept-encoding: gzip,deflate
 body: {\"query\":\"cat\",\"page\":{\"size\":1},\"filters\":{\"license\":\"BSD\"},\"facets\":{\"license\":[{\"type\":\"value\",\"size\":3}],\"dependencies\":[{\"type\":\"value\",\"size\":3}]}}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153808178540179732
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153808178540179732
@@ -2,7 +2,7 @@ POST /api/as/v1/engines/node-modules/search.json
 authorization: Bearer api-hean6g8dmxnm2shqqiag757a
 content-type: application/json
 x-swiftype-client: swiftype-app-search-javascript
-x-swiftype-client-version: 1.4.0
+x-swiftype-client-version: 2.0.0
 accept: */*
 accept-encoding: gzip,deflate
 body: {\"query\":\"cat\",\"page\":{\"size\":1},\"filters\":{},\"facets\":{\"dependencies\":[{\"type\":\"value\",\"size\":3}]}}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153808178542296611
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153808178542296611
@@ -2,7 +2,7 @@ POST /api/as/v1/engines/node-modules/search.json
 authorization: Bearer api-hean6g8dmxnm2shqqiag757a
 content-type: application/json
 x-swiftype-client: swiftype-app-search-javascript
-x-swiftype-client-version: 1.4.0
+x-swiftype-client-version: 2.0.0
 accept: */*
 accept-encoding: gzip,deflate
 body: {\"query\":\"cat\",\"page\":{\"size\":1},\"filters\":{\"dependencies\":\"socket.io\"},\"facets\":{\"license\":[{\"type\":\"value\",\"size\":3}]}}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153808227733258899
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153808227733258899
@@ -2,7 +2,7 @@ POST /api/as/v1/engines/node-modules/search.json
 authorization: Bearer api-hean6g8dmxnm2shqqiag757a
 content-type: application/json
 x-swiftype-client: swiftype-app-search-javascript
-x-swiftype-client-version: 1.4.0
+x-swiftype-client-version: 2.0.0
 accept: */*
 accept-encoding: gzip,deflate
 body: {\"query\":\"cat\",\"page\":{\"size\":1},\"filters\":{\"all\":[]},\"facets\":{\"dependencies\":[{\"type\":\"value\",\"size\":3}]}}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153808227737563491
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153808227737563491
@@ -2,7 +2,7 @@ POST /api/as/v1/engines/node-modules/search.json
 authorization: Bearer api-hean6g8dmxnm2shqqiag757a
 content-type: application/json
 x-swiftype-client: swiftype-app-search-javascript
-x-swiftype-client-version: 1.4.0
+x-swiftype-client-version: 2.0.0
 accept: */*
 accept-encoding: gzip,deflate
 body: {\"query\":\"cat\",\"page\":{\"size\":1},\"filters\":{\"all\":[{\"dependencies\":\"socket.io\"}]},\"facets\":{\"license\":[{\"type\":\"value\",\"size\":3}]}}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153808227744616148
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153808227744616148
@@ -2,7 +2,7 @@ POST /api/as/v1/engines/node-modules/search.json
 authorization: Bearer api-hean6g8dmxnm2shqqiag757a
 content-type: application/json
 x-swiftype-client: swiftype-app-search-javascript
-x-swiftype-client-version: 1.4.0
+x-swiftype-client-version: 2.0.0
 accept: */*
 accept-encoding: gzip,deflate
 body: {\"query\":\"cat\",\"page\":{\"size\":1},\"filters\":{\"all\":[{\"license\":\"BSD\"},{\"dependencies\":\"socket.io\"}]},\"facets\":{\"license\":[{\"type\":\"value\",\"size\":3}],\"dependencies\":[{\"type\":\"value\",\"size\":3}]}}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153808315298088051
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153808315298088051
@@ -2,7 +2,7 @@ POST /api/as/v1/engines/node-modules/search.json
 authorization: Bearer api-hean6g8dmxnm2shqqiag757a
 content-type: application/json
 x-swiftype-client: swiftype-app-search-javascript
-x-swiftype-client-version: 1.4.0
+x-swiftype-client-version: 2.0.0
 accept: */*
 accept-encoding: gzip,deflate
 body: {\"query\":\"cat\",\"page\":{\"size\":1},\"filters\":{\"all\":[{\"license\":\"BSD\"}]},\"facets\":{\"dependencies\":[{\"type\":\"value\",\"size\":3}]}}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153816524493912475
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153816524493912475
@@ -2,7 +2,7 @@ POST /api/as/v1/engines/node-modules/search.json
 authorization: Bearer api-hean6g8dmxnm2shqqiag757a
 content-type: application/json
 x-swiftype-client: swiftype-app-search-javascript
-x-swiftype-client-version: 1.4.0
+x-swiftype-client-version: 2.0.0
 accept: */*
 accept-encoding: gzip,deflate
 body: {\"query\":\"cat\",\"page\":{\"size\":1},\"filters\":{\"all\":[{\"license\":\"BSD\"},{\"dependencies\":\"socket.io\"}]},\"facets\":{\"license\":{\"type\":\"value\",\"size\":3},\"dependencies\":[{\"type\":\"value\",\"size\":3}]}}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153816524497823898
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153816524497823898
@@ -2,7 +2,7 @@ POST /api/as/v1/engines/node-modules/search.json
 authorization: Bearer api-hean6g8dmxnm2shqqiag757a
 content-type: application/json
 x-swiftype-client: swiftype-app-search-javascript
-x-swiftype-client-version: 1.4.0
+x-swiftype-client-version: 2.0.0
 accept: */*
 accept-encoding: gzip,deflate
 body: {\"query\":\"cat\",\"page\":{\"size\":1},\"filters\":{\"all\":[{\"dependencies\":\"socket.io\"}]},\"facets\":{\"license\":{\"type\":\"value\",\"size\":3}}}

--- a/fixtures/host-2376rb.api.swiftype.com-443/153867377948487845
+++ b/fixtures/host-2376rb.api.swiftype.com-443/153867377948487845
@@ -2,7 +2,7 @@ POST /api/as/v1/engines/node-modules/search.json
 authorization: Bearer api-hean6g8dmxnm2shqqiag757a
 content-type: application/json
 x-swiftype-client: swiftype-app-search-javascript
-x-swiftype-client-version: 1.4.0
+x-swiftype-client-version: 2.0.0
 accept: */*
 accept-encoding: gzip,deflate
 body: {\"query\":\"cat\",\"page\":{\"size\":1},\"group\":{\"field\":\"license\"}}

--- a/fixtures/localhost.swiftype.com-3002/153796801309977962
+++ b/fixtures/localhost.swiftype.com-3002/153796801309977962
@@ -2,7 +2,7 @@ POST /api/as/v1/engines/node-modules/search.json
 authorization: Bearer api-hean6g8dmxnm2shqqiag757a
 content-type: application/json
 x-swiftype-client: swiftype-app-search-javascript
-x-swiftype-client-version: 1.4.0
+x-swiftype-client-version: 2.0.0
 accept: */*
 accept-encoding: gzip,deflate
 body: {\"query\":\"cat\"}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swiftype-app-search-javascript",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "Javascript client for the Swiftype App Search Api",
   "browser": "dist/swiftype_app_search.umd.js",
   "main": "dist/swiftype_app_search.umd.js",

--- a/src/client.js
+++ b/src/client.js
@@ -34,7 +34,7 @@ export default class Client {
     hostIdentifier,
     apiKey,
     engineName,
-    { endpointBase = "", cacheResponses = false } = {}
+    { endpointBase = "", cacheResponses = true } = {}
   ) {
     this.apiKey = apiKey;
     this.cacheResponses = cacheResponses;


### PR DESCRIPTION
- Documented caching behavior and search response types
- Changed caching to be enabled by default
- Updated version to 2.0.0

## 2.0 release details
- `_group` field in `search` responses will now be wrapped in `ResultItem`, to be consistent with top level result items.
- API Responses are now cached by default. An additional option, `cacheResponses` is available to disable this behavior. Closes #39.
- Adds Disjunctive Faceting through a new `disjunctiveFacets` option, available on the `search` method.
