### PR TITLE
POC sticky facets API.

### DIFF
--- a/src/facets.js
+++ b/src/facets.js
@@ -1,0 +1,89 @@
+function removeInvalidPropertyFromFacetDefinition(facetDefinition) {
+  var newDefinition = Object.assign({}, facetDefinition);
+
+  if (newDefinition.sticky !== null) delete newDefinition.sticky;
+
+  if (newDefinition.currentValue !== null) delete newDefinition.currentValue;
+
+  return newDefinition;
+}
+
+/**
+ * A helper for working with the JSON structure which represent
+ * facets in API requests.
+ */
+export default class Facets {
+  constructor(facetsJSON = {}) {
+    this.facetsJSON = facetsJSON;
+  }
+
+  getStickyFacets() {
+    return Object.entries(this.facetsJSON ? this.facetsJSON : {})
+      .filter(([facetName, facetDefinition]) => facetDefinition.sticky === true)
+      .map(([facetName, facetDefinition]) => [
+        facetName,
+        removeInvalidPropertyFromFacetDefinition(facetDefinition)
+      ])
+      .reduce(function(acc, [facetName, facetDefinition]) {
+        acc[facetName] = facetDefinition;
+        return acc;
+      }, {});
+  }
+
+  getBaseQueryFacets() {
+    return Object.entries(this.facetsJSON ? this.facetsJSON : {})
+      .filter(([facetName, facetDefinition]) => facetDefinition.sticky !== true)
+      .map(([facetName, facetDefinition]) => [
+        facetName,
+        removeInvalidPropertyFromFacetDefinition(facetDefinition)
+      ])
+      .reduce(function(acc, [facetName, facetDefinition]) {
+        acc[facetName] = facetDefinition;
+        return acc;
+      }, {});
+  }
+
+  getFacetFilters(exclude) {
+    return Object.entries(this.facetsJSON ? this.facetsJSON : {})
+      .filter(
+        ([facetName, facetDefinition]) =>
+          facetDefinition.currentValue !== null && facetName !== exclude
+      )
+      .map(([facetName, facetDefinition]) => {
+        const filter = {};
+        if (
+          facetDefinition.sticky ||
+          !Array.isArray(facetDefinition.currentValue)
+        ) {
+          filter[facetName] = facetDefinition.currentValue;
+        } else {
+          filter["all"] = facetDefinition.currentValue.map(currentValue => {
+            const currentValueFilter = {};
+            currentValueFilter[facetName] = currentValue;
+            return currentValueFilter;
+          });
+        }
+        return filter;
+      });
+  }
+
+  addFacetFilters(baseFilters, exclude) {
+    var filters =
+      baseFilters && baseFilters["all"]
+        ? baseFilters["all"]
+        : baseFilters
+          ? [baseFilters]
+          : [];
+    var facetsFilters = this.getFacetFilters(exclude);
+
+    if (filters || facetsFilters.length > 0) {
+      var filters = facetsFilters.concat(filters);
+    }
+
+    return filters.length > 1
+      ? { all: filters }
+      : filters.length > 0
+        ? filters[0]
+        : null;
+  }
+}


### PR DESCRIPTION
This is a draft PR that aims to share my thoughts on a possible sticky facet API and a possible implementation.

First I have added a sticky flag in the facet definition. When enabled, the facet is disjunctive:

```javascript
var searchOptions = {
  "facets": {
    "city" : {"type": "value", "size": 5, "sticky": true},
    "tags" : {"type": "value", "size": 5},
    "live_music" : {"type": "value"}
  }
}
          
client.search("", searchOptions);
```

If the user choose a value for the facet, it should not be added into the `filters` but at the facet level in the currrentValue properties.

When the user have chosen a single value:
```javascript
var searchOptions = {
  "facets": {
    "city" : {"type": "value", "size": 5, "currentValue":  "New York", "sticky": true},
    "tags" : {"type": "value", "size": 5},
    "live_music" : {"type": "value"}
  }
}
          
client.search("", searchOptions);
```
On multiple values:
```javascript
var searchOptions = {
  "facets": {
    "city" : {"type": "value", "size": 5, "currentValue": ["San Francisco", "New York"], "sticky": true},
    "tags" : {"type": "value", "size": 5},
    "live_music" : {"type": "value"}
  }
}
          
client.search("", searchOptions);
```

The tags facets is not sticky. It means filters are applied using an AND operator. You have the same syntax to apply filters on tags:

```javascript
var searchOptions = {
  "facets": {
    "city" : {"type": "value", "size": 5, "sticky": true},
    "tags" : {"type": "value", "size": 5, "currentValue": ["Bars", "Featured"]},
    "live_music" : {"type": "value"}
  }
}
          
client.search("", searchOptions);
```

Code need to be cleansed and tested.